### PR TITLE
Prevent exception when no rem values used in passed stylesheet

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,17 +18,21 @@ var transform = function(file, opts) {
 		temp 	= '',
 		match 	= css.match(regex);
 
-	for (i=0; i < match.length; i++) {
+	if (match) {
 
-		temp = temp || css,
+		for (i=0; i < match.length; i++) {
 
-		split = match[i].split('rem'),
+			temp = temp || css,
 
-		px = parseInt(split[0] * fontSize) + 'px',
+			split = match[i].split('rem'),
 
-		value = match[i].replace(match[i], px);
+			px = parseInt(split[0] * fontSize) + 'px',
 
-		temp = temp.replace(single, value);
+			value = match[i].replace(match[i], px);
+
+			temp = temp.replace(single, value);
+
+		}
 
 	}
 


### PR DESCRIPTION
This prevents the following exception occurring when there are no rem values in a passed stylesheet (this would be an issue if this plugin is included in any boilerplate, or if pre-emtpively added before one starts to add rem values to the CSS):

```
/home/ravenous/dev/mintgreen-website/node_modules/gulp-rem-to-px/index.js:21
    for (i=0; i < match.length; i++) {
                       ^
TypeError: Cannot read property 'length' of null
    at transform (/home/ravenous/dev/mintgreen-website/node_modules/gulp-rem-to-px/index.js:21:21)
    at DestroyableTransform._transform (/home/ravenous/dev/mintgreen-website/node_modules/gulp-rem-to-px/index.js:55:20)
    at DestroyableTransform.Transform._read (/home/ravenous/dev/mintgreen-website/node_modules/gulp-rem-to-px/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/home/ravenous/dev/mintgreen-website/node_modules/gulp-rem-to-px/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/home/ravenous/dev/mintgreen-website/node_modules/gulp-rem-to-px/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/home/ravenous/dev/mintgreen-website/node_modules/gulp-rem-to-px/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/home/ravenous/dev/mintgreen-website/node_modules/gulp-rem-to-px/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at Stream.ondata (stream.js:51:26)
    at Stream.emit (events.js:95:17)
    at queueData (/home/ravenous/dev/mintgreen-website/node_modules/gulp-sass/node_modules/map-stream/index.js:43:21)
```
