### PR TITLE
still use original file when has no rem & refine coding style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_store
 .DS_Store?
-
+.idea
 npm-debug.log
 node_modules
 *.sublime*

--- a/index.js
+++ b/index.js
@@ -1,72 +1,77 @@
-var through 	= require('through2'),
-	gutil		= require('gulp-util'),
-	PluginError = gutil.PluginError;
+var through = require('through2'),
+    gutil = require('gulp-util'),
+    PluginError = gutil.PluginError;
 
 const PLUGIN_NAME = 'gulp-rem-to-px';
 
 var transform = function(file, opts) {
 
-	opts 	= opts || {};
+    opts = opts || {};
 
-	var fontSize = (opts.fontSize == null) ? 16 : opts.fontSize;
+    var fontSize = (opts.fontSize == null) ? 16 : opts.fontSize;
 
-	var css		= file.toString('utf8'),
+    var css = file.toString('utf8'),
 
-		regex 	= /\-?([0-9])*\.?([0-9])+([r][e][m])/g,
-		single 	= /\-?([0-9])*\.?([0-9])+([r][e][m])/,
+        regex = /\-?([0-9])*\.?([0-9])+([r][e][m])/g,
+        single = /\-?([0-9])*\.?([0-9])+([r][e][m])/,
 
-		temp 	= '',
-		match 	= css.match(regex);
+        temp = '',
+        split,
+        px,
+        value,
+        match = css.match(regex);
 
-	if (match) {
+    if (match) {
 
-		for (i=0; i < match.length; i++) {
+        for (var i = 0; i < match.length; i++) {
 
-			temp = temp || css,
+            temp = temp || css,
 
-			split = match[i].split('rem'),
+            split = match[i].split('rem'),
 
-			px = parseInt(split[0] * fontSize) + 'px',
+            px = parseInt(split[0] * fontSize) + 'px',
 
-			value = match[i].replace(match[i], px);
+            value = match[i].replace(match[i], px);
 
-			temp = temp.replace(single, value);
+            temp = temp.replace(single, value);
 
-		}
+        }
 
-	}
+    } else {
+        temp = css;
+    }
 
-	temp = new Buffer(temp);
+    temp = new Buffer(temp);
 
-	return temp;
+    return temp;
 
 }
 
 
 var remToPx = function(opts) {
 
-	var stream = through.obj(function(file, enc, cb) {
-		
-		if (file.isStream()) {
+    var stream = through.obj(function(file, enc, cb) {
+        
+        if (file.isStream()) {
 
-			this.emit('error', new PluginError(PLUGIN_NAME, 'Streams not supported!'));
-			return cb();
+            this.emit('error', new PluginError(PLUGIN_NAME, 'Streams not supported!'));
+            return cb();
 
-		}
+        }
 
-		if (file.isBuffer()) {
-			
-			file.contents = transform(file.contents, opts);
+        if (file.isBuffer()) {
+            
+            file.contents = transform(file.contents, opts);
 
-		}
+        }
 
-		this.push(file);
+        this.push(file);
 
-		cb();
+        cb();
 
-	});
+    });
 
-	return stream;
+    return stream;
 
 }
 


### PR DESCRIPTION
1. Fix bug: when one file has no "rem", the file will be lost. So, still use original file when has no rem.
2. Refine coding style. Replace tab with four white spaces.
